### PR TITLE
Add theme skeleton with basic UI components

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -1,0 +1,26 @@
+<?php get_header(); ?>
+<section class="section">
+  <div class="container">
+    <h1 class="section-title"><?php the_archive_title(); ?></h1>
+    <?php if (have_posts()) : ?>
+    <div class="cards-grid">
+      <?php while (have_posts()) : the_post(); ?>
+      <article <?php post_class('card'); ?>>
+        <div class="card-body">
+          <h2 class="card-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+          <p class="card-description"><?php echo get_the_excerpt(); ?></p>
+        </div>
+        <div class="card-footer">
+          <span class="badge"><?php echo get_the_date(); ?></span>
+          <a class="btn btn-ghost btn-sm" href="<?php the_permalink(); ?>">Read &rarr;</a>
+        </div>
+      </article>
+      <?php endwhile; ?>
+    </div>
+    <?php the_posts_navigation(); ?>
+    <?php else : ?>
+    <p><?php esc_html_e('No posts found.', 'glorygod'); ?></p>
+    <?php endif; ?>
+  </div>
+</section>
+<?php get_footer(); ?>

--- a/assets/css/ui.css
+++ b/assets/css/ui.css
@@ -1,0 +1,86 @@
+/* Variables */
+:root {
+  --brand-primary:#5E5CE6;
+  --brand-primary-dark:#5451D6;
+  --brand-primary-light:#7A78F0;
+  --brand-primary-subtle:#F5F5FF;
+  --brand-primary-muted:#EEEEFF;
+
+  --neutral-50:#FFFFFF;
+  --neutral-100:#F5F5F5;
+  --neutral-200:#E5E5E5;
+  --neutral-300:#D4D4D4;
+  --neutral-400:#A3A3A3;
+  --neutral-600:#525252;
+  --neutral-900:#171717;
+  --neutral-1000:#000000;
+}
+
+* { box-sizing:border-box; }
+
+body {
+  margin:0;
+  font-family:'Inter', system-ui, sans-serif;
+  color:var(--neutral-900);
+  background:var(--neutral-50);
+  padding-top:64px;
+}
+
+/* Layout */
+.container {
+  max-width:1200px;
+  margin:0 auto;
+  padding:0 1rem;
+}
+.section { padding:2rem 0; }
+.section-title { font-size:2rem; margin:0 0 1rem; }
+.section-description { color:var(--neutral-600); }
+.divider { height:1px; background:var(--neutral-200); margin:2rem 0; }
+
+/* Nav */
+.nav {
+  position:fixed;
+  top:0; left:0;
+  width:100%; height:64px;
+  background:var(--neutral-50);
+  border-bottom:1px solid var(--neutral-200);
+  display:flex; align-items:center;
+  z-index:1000;
+}
+.nav-container {
+  display:flex; align-items:center; justify-content:space-between;
+  max-width:1200px; width:100%; margin:0 auto; padding:0 1rem;
+}
+.logo-link { display:flex; align-items:center; gap:0.5rem; text-decoration:none; color:inherit; }
+.logo-mark { width:24px; height:24px; background:var(--brand-primary); border-radius:4px; }
+.nav-center { flex:1; text-align:center; }
+.nav-center ul { list-style:none; margin:0; padding:0; display:inline-flex; gap:1rem; }
+.nav-link { text-decoration:none; color:var(--neutral-900); padding:0.5rem; border-radius:4px; transition:background .2s, color .2s; }
+.nav-link:hover, .nav-link:focus { background:var(--brand-primary-subtle); color:var(--brand-primary-dark); }
+
+/* Buttons */
+.btn {
+  display:inline-flex; align-items:center; justify-content:center;
+  padding:0.5rem 1rem; border:1px solid transparent;
+  border-radius:4px; cursor:pointer; text-decoration:none;
+  font-size:0.875rem; transition:background .2s, box-shadow .2s, transform .2s;
+}
+.btn:hover, .btn:focus { box-shadow:0 2px 6px rgba(0,0,0,0.1); transform:translateY(-1px); }
+.btn-primary { background:var(--brand-primary); color:#fff; }
+.btn-primary:hover, .btn-primary:focus { background:var(--brand-primary-dark); }
+.btn-ghost { background:transparent; border-color:var(--neutral-200); color:var(--neutral-900); }
+.btn-ghost:hover, .btn-ghost:focus { background:var(--neutral-100); }
+.btn-sm { padding:0.25rem 0.75rem; font-size:0.75rem; }
+
+/* Cards */
+.cards-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:1.5rem; }
+.card { border:1px solid var(--neutral-200); border-radius:8px; background:var(--neutral-50); display:flex; flex-direction:column; justify-content:space-between; transition:box-shadow .2s; }
+.card:hover { box-shadow:0 2px 6px rgba(0,0,0,0.08); }
+.card-body { padding:1rem; }
+.card-title { margin:0 0 0.5rem; font-size:1.25rem; }
+.card-description { color:var(--neutral-600); font-size:0.875rem; }
+.card-footer { padding:1rem; border-top:1px solid var(--neutral-200); display:flex; align-items:center; justify-content:space-between; }
+
+/* Badge */
+.badge { display:inline-block; padding:0.25rem 0.5rem; background:var(--brand-primary-muted); color:var(--brand-primary-dark); border-radius:4px; font-size:0.75rem; }
+

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,7 @@
+</main>
+<footer class="footer container">
+  <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></p>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,22 @@
+<?php
+
+function glorygod_theme_setup() {
+    add_theme_support('title-tag');
+    register_nav_menus([
+        'main' => __('Главное меню', 'glorygod'),
+    ]);
+}
+add_action('after_setup_theme', 'glorygod_theme_setup');
+
+function glorygod_enqueue_assets() {
+    wp_enqueue_style('glorygod-ui', get_template_directory_uri() . '/assets/css/ui.css', [], '1.0');
+    wp_enqueue_style('glorygod-style', get_stylesheet_uri());
+}
+add_action('wp_enqueue_scripts', 'glorygod_enqueue_assets');
+
+function glorygod_nav_link_class($atts, $item, $args) {
+    $atts['class'] = trim(($atts['class'] ?? '') . ' nav-link');
+    return $atts;
+}
+add_filter('nav_menu_link_attributes', 'glorygod_nav_link_class', 10, 3);
+

--- a/header.php
+++ b/header.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo('charset'); ?>">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<header class="nav">
+  <div class="nav-container">
+    <div class="nav-left">
+      <a href="<?php echo esc_url(home_url('/')); ?>" class="logo-link">
+        <span class="logo-mark"></span>
+        <span class="site-title"><?php bloginfo('name'); ?></span>
+      </a>
+    </div>
+    <div class="nav-center">
+      <?php wp_nav_menu([
+        'theme_location' => 'main',
+        'container'      => false,
+        'fallback_cb'    => false
+      ]); ?>
+    </div>
+    <div class="nav-right">
+      <a href="<?php echo esc_url(is_user_logged_in() ? admin_url() : wp_login_url()); ?>" class="btn btn-ghost btn-sm"><?php echo is_user_logged_in() ? 'Админка' : 'Sign in'; ?></a>
+      <a href="#" class="btn btn-primary btn-sm">Get started</a>
+    </div>
+  </div>
+</header>
+<main class="site-main">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,26 @@
+<?php get_header(); ?>
+<section class="section">
+  <div class="container">
+    <h1 class="section-title"><?php bloginfo('name'); ?></h1>
+    <?php if (have_posts()) : ?>
+    <div class="cards-grid">
+      <?php while (have_posts()) : the_post(); ?>
+      <article <?php post_class('card'); ?>>
+        <div class="card-body">
+          <h2 class="card-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+          <p class="card-description"><?php echo get_the_excerpt(); ?></p>
+        </div>
+        <div class="card-footer">
+          <span class="badge"><?php echo get_the_date(); ?></span>
+          <a class="btn btn-ghost btn-sm" href="<?php the_permalink(); ?>">Read &rarr;</a>
+        </div>
+      </article>
+      <?php endwhile; ?>
+    </div>
+    <?php the_posts_navigation(); ?>
+    <?php else : ?>
+    <p><?php esc_html_e('No posts found.', 'glorygod'); ?></p>
+    <?php endif; ?>
+  </div>
+</section>
+<?php get_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<section class="section">
+  <div class="container">
+    <?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+      <h1 class="section-title"><?php the_title(); ?></h1>
+      <div class="section-description"><?php the_content(); ?></div>
+    <?php endwhile; endif; ?>
+  </div>
+</section>
+<?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<section class="section">
+  <div class="container">
+    <?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+      <h1 class="section-title"><?php the_title(); ?></h1>
+      <div class="section-description"><?php the_content(); ?></div>
+    <?php endwhile; endif; ?>
+  </div>
+</section>
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,10 @@
+/*
+Theme Name: Glory God
+Theme URI: https://example.com/
+Author: AI
+Description: Minimal starter theme with basic UI components.
+Version: 0.1
+Text Domain: glorygod
+*/
+
+/* Theme base styles can go here */


### PR DESCRIPTION
## Summary
- add classic theme structure with required templates
- register main menu and enqueue UI stylesheet
- implement fixed header with logo, menu, and CTA buttons
- style base components (layout, nav, buttons, cards, badges)
- display posts as card grid on index and archive pages

## Testing
- `php -l functions.php`
- `php -l header.php`
- `php -l footer.php`
- `php -l index.php`
- `php -l single.php`
- `php -l archive.php`
- `php -l page.php`

------
https://chatgpt.com/codex/tasks/task_e_6897c8a1bb68832da6c3382d2689d7a8